### PR TITLE
Fix three pre-existing d3i bugs (import-merge, debug leftover, view-member lint)Fix three pre-existing bugs (import-merge, debug leftover, view-membe…

### DIFF
--- a/d3i/Engine.py
+++ b/d3i/Engine.py
@@ -238,7 +238,7 @@ class Engine:
                             # merge composite
                             for imported_composit in imported_context.composites:
                                 imported_composit.parent = context_already
-                                context_already.composit.append(imported_composit)
+                                context_already.composites.append(imported_composit)
 
                             # merge aggregate
                             for imported_aggregate in imported_context.aggregates:
@@ -301,9 +301,6 @@ class Engine:
         version_candidate: str = None
         if (len(name.names) > 1):
             version_candidate = name.names[1]
-
-        if( name.getText() == "LoginIF.v1.LoginResultDTO" ):
-            pass
 
         rest_name_index = 1
         # go up until we find the element for the first part of the name vit version is has it

--- a/d3i/linters/SemanticChecker.py
+++ b/d3i/linters/SemanticChecker.py
@@ -242,7 +242,7 @@ class SemanticChecker(ElementVisitor):
             if (neighbour is view_member):
                 continue
             if (neighbour.name == view_member.name):
-                self.__error__(view_member, f"A member '{view_member.name}' conflicts with same name with element in {neighbour.locationText()}.")
+                self.__error(view_member, f"A member '{view_member.name}' conflicts with same name with element in {neighbour.locationText()}.")
 
     def visitRepository(self, repository: repository, parentData: Any) -> Any:
         scope = Engine.get_current_scope(repository.parent)

--- a/tests/test_linter_semantic_checker.py
+++ b/tests/test_linter_semantic_checker.py
@@ -963,6 +963,27 @@ domain SomeDomain {
         self.assertEqual(len(session.diagnostics), 1)
         self.assertTrue("list can only contain" in session.diagnostics[0].toText())
 
+    def test_conflict_view_member_fail(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain SomeDomain {
+    context Order {
+        view TheView {
+            member:string
+            member:integer
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        self.assertFalse(session.HasAnyError())
+
+        checker = SemanticChecker(session)
+        data = root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 2)
+        self.assertTrue(all("member" in s.toText() and "conflicts" in s.toText() for s in session.diagnostics))
+
     def test_any_on_field_fail(self):
         engine = Engine()
         session = Session(Source.CreateFromText("""


### PR DESCRIPTION
…r lint)

- Engine.py: context_already.composit -> composites in the import-merge loop (the wrong attribute name crashed merging imported composites).
- Engine.py: remove the dead `if name.getText() == "LoginIF.v1.LoginResultDTO"` debug leftover in name resolution.
- SemanticChecker.py: self.__error__ -> self.__error for the view-member name conflict (the typo'd name raised AttributeError, so a view with duplicate members crashed the checker instead of reporting). Adds a regression test.