### PR TITLE
Lint: interface surface = dto/enum/primitive only

### DIFF
--- a/d3i/linters/SemanticChecker.py
+++ b/d3i/linters/SemanticChecker.py
@@ -351,6 +351,11 @@ class SemanticChecker(ElementVisitor):
         elif (isinstance(element, aggregate)):
             name = reference_type.reference_name.getText()
             self.__error(reference_type, f"Aggregate '{name}' must be referenced by identity: use 'ref {name}'.")
+        # an interface is the wire surface: it may only expose dto/enum/primitive types
+        # (plus `ref`, which is a string on the wire). Domain types must not leak onto it.
+        elif (self.__is_on_interface_surface(reference_type) and isinstance(element, (dto, enum)) == False):
+            name = reference_type.reference_name.getText()
+            self.__error(reference_type, f"An interface may only expose dto, enum and primitive types on its surface; '{name}' is a {element.__class__.__name__}. Map it to a dto for the wire contract.")
 
     def visitRefType(self, ref_type: ref_type, parentData: Any, memberName: str) -> Any:
         if (len(ref_type.reference_name.names) == 0):
@@ -399,6 +404,19 @@ class SemanticChecker(ElementVisitor):
 
     def __error(self, element: base_element, msg: str):
         self.session.ReportDiagnostic(msg, Diagnostic.Severity.Error, element.fileName, element.line, element.column)
+
+    def __is_on_interface_surface(self, element: base_element) -> bool:
+        # True when the element sits inside an interface (its dto members or its
+        # operation params/returns) — the versioned wire surface. Walking up stops at
+        # the context/domain boundary so domain fields never match.
+        node = element
+        while (node != None):
+            if (isinstance(node, interface)):
+                return True
+            if (isinstance(node, (context, domain, d3))):
+                return False
+            node = node.parent
+        return False
 
     def visitInternalScopedBaseElement(self, internal_scoped_base_element: internal_scoped_base_element, parentData: Any) -> Any:
         pass

--- a/tests/test_linter_semantic_checker.py
+++ b/tests/test_linter_semantic_checker.py
@@ -1176,5 +1176,80 @@ domain SomeDomain {
         self.assertEqual(len(session.diagnostics), 1)
         self.assertTrue("Value of map can only contain" in session.diagnostics[0].toText())
 
+    def test_interface_surface_valueobject_member_fail(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain SomeDomain {
+    context Order {
+        valueobject Money { amount:number }
+        interface OrderIF version 1 {
+            dto OrderDto {
+                total: Money
+            }
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        self.assertFalse(session.HasAnyError())
+
+        checker = SemanticChecker(session)
+        data = root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 1)
+        self.assertTrue("may only expose dto, enum and primitive" in session.diagnostics[0].toText())
+        self.assertTrue("Money" in session.diagnostics[0].toText())
+
+    def test_interface_surface_operation_param_fail(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain SomeDomain {
+    context Order {
+        valueobject Money { amount:number }
+        interface OrderIF version 1 {
+            query convert( m: Money ) : string
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        self.assertFalse(session.HasAnyError())
+
+        checker = SemanticChecker(session)
+        data = root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 1)
+        self.assertTrue("may only expose dto, enum and primitive" in session.diagnostics[0].toText())
+
+    def test_interface_surface_ok(self):
+        # dto/enum/primitive members and a ref (string on the wire) are all allowed.
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain SomeDomain {
+    context Order {
+        aggregate Customer {
+            root entity CustomerRoot { id:string }
+        }
+        interface OrderIF version 1 {
+            enum Status { New, Done }
+            dto Line { sku:string }
+            dto OrderDto {
+                id: string
+                status: Status
+                line: Line
+                owner: ref Customer
+            }
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        self.assertFalse(session.HasAnyError())
+
+        checker = SemanticChecker(session)
+        data = root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 0)
+
 if __name__ == "__main__":
     unittest.main()

--- a/todo.txt
+++ b/todo.txt
@@ -22,4 +22,7 @@ TODO — d3i
     - workflow Temporal runtime implementation
     - LSP: language_server.py calls main_module.lsp_initialize / lsp_did_open_text which
       are not defined in __main__.py -> broken; fix + smoke test.
-    - lint: "interface surface = only DTO/enum/primitive"
+
+[done] interface surface lint: an interface may only expose dto/enum/primitive types
+       (plus `ref` -> string, and list/map of those); domain types (value_object,
+       entity, view, composite, aggregate) may not leak onto the wire surface.


### PR DESCRIPTION
An `interface` is the versioned wire surface, so its dto members and operation params/returns may only be a **dto, enum or primitive** (a `ref` is a string on the wire; list/map of allowed types are fine). Domain types — value object, entity, view, composite, aggregate — must not leak onto it; map them to a dto for the wire contract.

Reported from `visitReferenceType` via a small `__is_on_interface_surface` walk (stops at the context/domain boundary, so domain-model fields never match). 3 new tests. 155 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)