### PR TITLE
validate: AST, lint, and .NET IValidable codegen

### DIFF
--- a/d3i/elements/ElementBuilder.py
+++ b/d3i/elements/ElementBuilder.py
@@ -35,10 +35,76 @@ class ElementBuilder(d3iGrammarVisitor):
         if (ctx.type_() != None):
             result.type = self.visit(ctx.type_())
             result.type.parent = result
-        if (hasattr(ctx, "validate_expr") and ctx.validate_expr() != None):
+        if (hasattr(ctx, "validate_expr") and ctx.validate_expr() != None and hasattr(result, "validate")):
             result.validate = ctx.validate_expr().getText()
+            result.validate_ast = self.__build_validate_expr(ctx.validate_expr())
         self.__build_document_lines(ctx, result)
         self.__build_decorators(ctx, result)
+
+    # --- validate expression sublanguage: parse tree -> validate_node AST ------------
+    def __build_validate_expr(self, ctx) -> validate_node:
+        if (ctx.validate_or() != None):
+            return self.__build_validate_or(ctx.validate_or())
+        return self.__build_validate_expr(ctx.validate_expr())
+
+    def __build_validate_or(self, ctx) -> validate_node:
+        ands = ctx.validate_and()
+        node = self.__build_validate_and(ands[0])
+        i = 1
+        while (i < len(ands)):
+            node = validate_binary("or", node, self.__build_validate_and(ands[i]))
+            i = i + 1
+        return node
+
+    def __build_validate_and(self, ctx) -> validate_node:
+        unaries = ctx.validate_unary()
+        node = self.__build_validate_unary(unaries[0])
+        i = 1
+        while (i < len(unaries)):
+            node = validate_binary("and", node, self.__build_validate_unary(unaries[i]))
+            i = i + 1
+        return node
+
+    def __build_validate_unary(self, ctx) -> validate_node:
+        if (ctx.NOT() != None):
+            return validate_not(self.__build_validate_unary(ctx.validate_unary()))
+        return self.__build_validate_predicate(ctx.validate_predicate())
+
+    def __build_validate_predicate(self, ctx) -> validate_node:
+        terms = ctx.validate_term()
+        left = self.__build_validate_term(terms[0])
+        if (ctx.IN() != None):
+            if (ctx.validate_range() != None):
+                rterms = ctx.validate_range().validate_term()
+                return validate_in_range(left, self.__build_validate_term(rterms[0]), self.__build_validate_term(rterms[1]))
+            items = [self.__build_validate_term(t) for t in ctx.validate_set().validate_term()]
+            return validate_in_set(left, items)
+        if (ctx.BETWEEN() != None):
+            return validate_between(left, self.__build_validate_term(terms[1]), self.__build_validate_term(terms[2]))
+        op = None
+        if (ctx.LT() != None): op = "<"
+        elif (ctx.LE() != None): op = "<="
+        elif (ctx.GT() != None): op = ">"
+        elif (ctx.GE() != None): op = ">="
+        elif (ctx.EQ() != None): op = "=="
+        elif (ctx.NEQ() != None): op = "!="
+        if (op != None):
+            return validate_binary(op, left, self.__build_validate_term(terms[1]))
+        return left
+
+    def __build_validate_term(self, ctx) -> validate_node:
+        if (ctx.IDENTIFIER() != None):
+            if (ctx.getChildCount() == 1):
+                return validate_ref(ctx.IDENTIFIER().getText())
+            args = [self.__build_validate_term(t) for t in ctx.validate_term()]
+            return validate_call(ctx.IDENTIFIER().getText(), args)
+        if (ctx.INTEGER_CONSTANS() != None):
+            return validate_literal("int", ctx.INTEGER_CONSTANS().getText())
+        if (ctx.NUMBER_CONSTANS() != None):
+            return validate_literal("number", ctx.NUMBER_CONSTANS().getText())
+        if (ctx.STRING_LITERAL() != None):
+            return validate_literal("string", ctx.STRING_LITERAL().getText())
+        return self.__build_validate_expr(ctx.validate_expr())
 
     # Visit a parse tree produced by d3iGrammar#d3i.
     def visitD3(self, ctx: d3iGrammar.D3Context):

--- a/d3i/elements/Elements.py
+++ b/d3i/elements/Elements.py
@@ -306,12 +306,62 @@ class value_object(internal_scoped_base_element):
             operation.visit(visitor, data)
 
 
+# --- validate expression AST (the `validate <expr>` sublanguage) ------------------
+# Built by ElementBuilder from the parse tree, consumed by the linter and the .NET
+# emitter. `validate` on a member keeps the raw text; `validate_ast` the structured form.
+class validate_node:
+    pass
+
+class validate_binary(validate_node):
+    # op in: 'or', 'and', '<', '<=', '>', '>=', '==', '!='
+    def __init__(self, op: str, left: validate_node, right: validate_node):
+        self.op = op
+        self.left = left
+        self.right = right
+
+class validate_not(validate_node):
+    def __init__(self, operand: validate_node):
+        self.operand = operand
+
+class validate_in_range(validate_node):   # term IN low..high
+    def __init__(self, term: validate_node, low: validate_node, high: validate_node):
+        self.term = term
+        self.low = low
+        self.high = high
+
+class validate_in_set(validate_node):     # term IN { a, b, c }
+    def __init__(self, term: validate_node, items: list):
+        self.term = term
+        self.items = items
+
+class validate_between(validate_node):    # term BETWEEN low AND high
+    def __init__(self, term: validate_node, low: validate_node, high: validate_node):
+        self.term = term
+        self.low = low
+        self.high = high
+
+class validate_call(validate_node):       # func(args...) e.g. len(value), matches(value, "..")
+    def __init__(self, func: str, args: list):
+        self.func = func
+        self.args = args
+
+class validate_ref(validate_node):        # 'value' (the member itself) or a sibling field name
+    def __init__(self, name: str):
+        self.name = name
+
+class validate_literal(validate_node):    # kind in 'int','number','string'
+    def __init__(self, kind: str, value: str):
+        self.kind = kind
+        self.value = value
+
+
 class value_object_member(hinted_base_element):
     def __init__(self, fileName, pos):
         super().__init__(fileName, pos)
         self.name: str = None
         self.type: type = None
         self.validate: str = None   # validate expression text, or None
+        self.validate_ast: validate_node = None
 
     def visit(self, visitor: ElementVisitor, parentData: Any):
         data = visitor.visitValueObjectMember(self, parentData)
@@ -367,6 +417,7 @@ class composite_member(hinted_base_element):
         self.name: str = None
         self.type: type = None
         self.validate: str = None   # validate expression text, or None
+        self.validate_ast: validate_node = None
 
     def visit(self, visitor: ElementVisitor, parentData: Any):
         data = visitor.visitCompositeMember(self, parentData)
@@ -443,6 +494,7 @@ class entity_member(hinted_base_element):
         self.name: str = None
         self.type: type = None
         self.validate: str = None   # validate expression text, or None
+        self.validate_ast: validate_node = None
 
     def visit(self, visitor: ElementVisitor, parentData: Any):
         data = visitor.visitEntityMember(self, parentData)

--- a/d3i/emitters/DotnetEmitter.py
+++ b/d3i/emitters/DotnetEmitter.py
@@ -323,7 +323,21 @@ class DotnetEmitter:
             else:
                 inherit_names.append(inherit.getText())
         inherit_names.append( f"IEquatable<{name}>")
-        
+
+        # collect members carrying a `validate` rule (inlined composite members + own members)
+        validate_members: List[hinted_base_element] = []
+        for base_composite in base_composites:
+            for composite_member in base_composite.members:
+                if (getattr(composite_member, "validate_ast", None) != None):
+                    validate_members.append(composite_member)
+        for own_member in members:
+            if (getattr(own_member, "validate_ast", None) != None):
+                validate_members.append(own_member)
+        if (len(validate_members) > 0):
+            inherit_names.append("IValidable")
+            code.usings.add("PolyPersist")
+            code.usings.add("PolyPersist.Net.Common")
+
         buffer = io.StringIO()
         # Add documentation lines for the composite
         buffer.write(self.documentLines(element, indent))
@@ -389,6 +403,10 @@ class DotnetEmitter:
         # Equal and HashCode
         buffer.write(self.dataClassEqualsAndHashCodeText(element, inherits, name, members, code, indent+1))
 
+        # Validation (IValidable) — only when some member carries a `validate` rule
+        if (len(validate_members) > 0):
+            buffer.write(self.dataClassValidateText(name, validate_members, code, indent+1))
+
         if ( utils.isPublishedOn(element.getInterface(), "grpc" ) == True and isinstance(element,dto)):
             buffer.write(self.dtoGrpcMappingText(element, code, indent+1))
 
@@ -397,6 +415,62 @@ class DotnetEmitter:
 
         code.content += buffer.getvalue()
         return code
+
+    def dataClassValidateText(self, name: str, validate_members: List[hinted_base_element], code: dotnet_code, indent: int = 1) -> str:
+        # Generates `bool Validate(IList<IValidationError> errors)` (PolyPersist.IValidable):
+        # one guard per member rule; a failing rule appends a ValidationError.
+        buffer = io.StringIO()
+        buffer.write(f"\n")
+        buffer.write(f"{utils.tab(indent)}#region Validation\n")
+        buffer.write(f"{utils.tab(indent)}public bool Validate( IList<IValidationError> errors )\n")
+        buffer.write(f"{utils.tab(indent)}{{\n")
+        buffer.write(f"{utils.tab(indent+1)}int __start = errors.Count;\n")
+        for member in validate_members:
+            condition = self.validateExprText(member.validate_ast, member.name, code)
+            # an @optional (nullable) member is only validated when present
+            if (member.find_decorator("optional") != None):
+                guard = f"this.{member.name} != null && !({condition})"
+            else:
+                guard = f"!({condition})"
+            errorText = member.validate.replace("\\", "\\\\").replace("\"", "\\\"")
+            buffer.write(f"{utils.tab(indent+1)}if ({guard})\n")
+            buffer.write(f"{utils.tab(indent+2)}errors.Add( new ValidationError {{ TypeOfEntity = \"{name}\", MemberOfEntity = \"{member.name}\", ErrorText = \"validation failed: {errorText}\" }} );\n")
+        buffer.write(f"{utils.tab(indent+1)}return errors.Count == __start;\n")
+        buffer.write(f"{utils.tab(indent)}}}\n")
+        buffer.write(f"{utils.tab(indent)}#endregion Validation\n")
+        return buffer.getvalue()
+
+    def validateExprText(self, node: validate_node, member_name: str, code: dotnet_code) -> str:
+        # maps a validate AST node to a C# boolean/value expression
+        if (isinstance(node, validate_binary)):
+            left = self.validateExprText(node.left, member_name, code)
+            right = self.validateExprText(node.right, member_name, code)
+            op = {"and": "&&", "or": "||"}.get(node.op, node.op)   # comparisons pass through
+            return f"({left} {op} {right})"
+        if (isinstance(node, validate_not)):
+            return f"(!({self.validateExprText(node.operand, member_name, code)}))"
+        if (isinstance(node, validate_in_range) or isinstance(node, validate_between)):
+            term = self.validateExprText(node.term, member_name, code)
+            low = self.validateExprText(node.low, member_name, code)
+            high = self.validateExprText(node.high, member_name, code)
+            return f"({term} >= {low} && {term} <= {high})"
+        if (isinstance(node, validate_in_set)):
+            term = self.validateExprText(node.term, member_name, code)
+            parts = [f"{term} == {self.validateExprText(item, member_name, code)}" for item in node.items]
+            return "(" + " || ".join(parts) + ")"
+        if (isinstance(node, validate_call)):
+            args = [self.validateExprText(arg, member_name, code) for arg in node.args]
+            if (node.func == "len"):
+                return f"({args[0]}).Length"
+            if (node.func == "matches"):
+                return f"System.Text.RegularExpressions.Regex.IsMatch({args[0]}, {args[1]})"
+            return f"{node.func}({', '.join(args)})"
+        if (isinstance(node, validate_ref)):
+            target = member_name if (node.name == "value") else node.name
+            return f"this.{target}"
+        if (isinstance(node, validate_literal)):
+            return node.value
+        return ""
 
     def dataClassEqualsAndHashCodeText(self, element: internal_scoped_base_element, inherits: List[qualified_name], name: str, members: List[hinted_base_element], code: dotnet_code, indent: int = 1) -> str:
         bases: List[internal_scoped_base_element] = []

--- a/d3i/linters/SemanticChecker.py
+++ b/d3i/linters/SemanticChecker.py
@@ -116,6 +116,7 @@ class SemanticChecker(ElementVisitor):
                 continue
             if (neighbour.name == member.name):
                 self.__error(member, f"An member '{member.name}' conflicts with same name with element in {neighbour.locationText()}.")
+        self.__check_validate(member)
 
     def visitDto(self, the_dto: dto, parentData: Any) -> Any:
         scope = Engine.get_current_scope(the_dto.parent)
@@ -164,6 +165,7 @@ class SemanticChecker(ElementVisitor):
                 continue
             if (neighbour.name == member.name):
                 self.__error(member, f"An member '{member.name}' conflicts with same name with element in {neighbour.locationText()}.")
+        self.__check_validate(member)
 
     def visitEntity(self, the_entity: entity, parentData: Any) -> Any:
         parent_aggregate: aggregate = the_entity.parent.parent
@@ -191,6 +193,7 @@ class SemanticChecker(ElementVisitor):
                 continue
             if (neighbour.name == entity_member.name):
                 self.__error(entity_member, f"A member '{entity_member.name}' conflicts with same name with element in {neighbour.locationText()}.")
+        self.__check_validate(entity_member)
 
     def visitAggregate(self, aggregate: aggregate, parentData: Any) -> Any:
         scope = Engine.get_current_scope(aggregate.parent)
@@ -404,6 +407,51 @@ class SemanticChecker(ElementVisitor):
 
     def __error(self, element: base_element, msg: str):
         self.session.ReportDiagnostic(msg, Diagnostic.Severity.Error, element.fileName, element.line, element.column)
+
+    # known validate functions -> required argument count
+    __VALIDATE_FUNCS = {"len": 1, "matches": 2}
+
+    def __check_validate(self, member: base_element):
+        node = member.validate_ast
+        if (node == None):
+            return
+        # the whole expression must be a boolean condition, not a bare value/literal.
+        if (isinstance(node, (validate_ref, validate_literal))):
+            self.__error(member, f"The 'validate' expression on '{member.name}' must be a boolean condition.")
+        sibling_names = [m.name for m in member.parent.members]
+        self.__walk_validate(node, member, sibling_names)
+
+    def __walk_validate(self, node, member: base_element, sibling_names: list):
+        if (isinstance(node, validate_binary)):
+            self.__walk_validate(node.left, member, sibling_names)
+            self.__walk_validate(node.right, member, sibling_names)
+        elif (isinstance(node, validate_not)):
+            self.__walk_validate(node.operand, member, sibling_names)
+        elif (isinstance(node, validate_in_range)):
+            self.__walk_validate(node.term, member, sibling_names)
+            self.__walk_validate(node.low, member, sibling_names)
+            self.__walk_validate(node.high, member, sibling_names)
+        elif (isinstance(node, validate_in_set)):
+            self.__walk_validate(node.term, member, sibling_names)
+            for item in node.items:
+                self.__walk_validate(item, member, sibling_names)
+        elif (isinstance(node, validate_between)):
+            self.__walk_validate(node.term, member, sibling_names)
+            self.__walk_validate(node.low, member, sibling_names)
+            self.__walk_validate(node.high, member, sibling_names)
+        elif (isinstance(node, validate_call)):
+            if (node.func not in self.__VALIDATE_FUNCS):
+                self.__error(member, f"Unknown function '{node.func}' in the 'validate' on '{member.name}' (known: len, matches).")
+            elif (len(node.args) != self.__VALIDATE_FUNCS[node.func]):
+                self.__error(member, f"Function '{node.func}' in the 'validate' on '{member.name}' expects {self.__VALIDATE_FUNCS[node.func]} argument(s), got {len(node.args)}.")
+            elif (node.func == "matches" and (isinstance(node.args[1], validate_literal) == False or node.args[1].kind != "string")):
+                self.__error(member, f"The second argument of 'matches' in the 'validate' on '{member.name}' must be a string regex literal.")
+            for arg in node.args:
+                self.__walk_validate(arg, member, sibling_names)
+        elif (isinstance(node, validate_ref)):
+            if (node.name != "value" and node.name not in sibling_names):
+                self.__error(member, f"'{node.name}' in the 'validate' on '{member.name}' is not 'value' nor a sibling field.")
+        # validate_literal: nothing to check
 
     def __is_on_interface_surface(self, element: base_element) -> bool:
         # True when the element sits inside an interface (its dto members or its

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1312,6 +1312,40 @@ domain SomeDomain {
         self.assertEqual(members["relatedCustomers"].type.kind, type.Kind.List)
         self.assertEqual(members["relatedCustomers"].type.item_type.kind, type.Kind.Ref)
 
+    def test_validate_ast_ok(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain D {
+    context C {
+        valueobject V {
+            amount: number validate value > 0 AND value <= 100
+            code: string validate len(value) == 4
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        members = {m.name: m for m in root.domains[0].contexts[0].value_objects[0].members}
+
+        # amount: an AND of two comparisons
+        amount = members["amount"].validate_ast
+        self.assertIsInstance(amount, validate_binary)
+        self.assertEqual(amount.op, "and")
+        self.assertIsInstance(amount.left, validate_binary)
+        self.assertEqual(amount.left.op, ">")
+        self.assertIsInstance(amount.left.left, validate_ref)
+        self.assertEqual(amount.left.left.name, "value")
+        self.assertIsInstance(amount.left.right, validate_literal)
+        self.assertEqual(amount.left.right.value, "0")
+
+        # code: a function call len(value) == 4
+        code = members["code"].validate_ast
+        self.assertIsInstance(code, validate_binary)
+        self.assertEqual(code.op, "==")
+        self.assertIsInstance(code.left, validate_call)
+        self.assertEqual(code.left.func, "len")
+        self.assertEqual(len(code.left.args), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_emitter_dotnet.py
+++ b/tests/test_emitter_dotnet.py
@@ -759,6 +759,42 @@ domain WebShop {
         # @gdpr is a marker only: it must not emit any attribute (exactly two [Obsolete]s)
         self.assertEqual(content.count("[Obsolete"), 2)
 
+    def test_emitter_validate_ok(self):
+        # a `validate` rule generates PolyPersist.IValidable.Validate with a guard per
+        # rule; inlined composite rules and @optional null-guards are handled too.
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain Shop {
+    context C {
+        composite WithZip {
+            zipCode: string validate len(value) == 4
+        }
+        valueobject Order inherits WithZip {
+            amount: number validate value > 0 AND value <= 1000
+            @optional
+            note: string validate len(value) <= 50
+        }
+    }
+}
+"""))
+        engine.Build(session)
+        self.assertFalse(session.HasAnyError())
+
+        result = DotnetEmitter().Emit(session)
+        content = next(f for f in result if f.fileName == "Order.cs").content
+
+        self.assertIn("using PolyPersist;", content)
+        self.assertIn("using PolyPersist.Net.Common;", content)
+        self.assertIn(", IValidable", content)
+        self.assertIn("public bool Validate( IList<IValidationError> errors )", content)
+        # own rule
+        self.assertIn("(this.amount > 0) && (this.amount <= 1000)", content)
+        # inlined composite rule (zipCode) lands in Order.Validate
+        self.assertIn('MemberOfEntity = "zipCode"', content)
+        self.assertIn("(this.zipCode).Length == 4", content)
+        # @optional member is guarded by a null-check
+        self.assertIn("this.note != null && !(", content)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_linter_semantic_checker.py
+++ b/tests/test_linter_semantic_checker.py
@@ -1251,5 +1251,81 @@ domain SomeDomain {
         session.PrintDiagnostics()
         self.assertEqual(len(session.diagnostics), 0)
 
+    def test_validate_ok(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain D {
+    context C {
+        valueobject V {
+            start: number
+            end: number validate value > start
+            name: string validate len(value) <= 10 AND matches(value, "^a")
+            grade: integer validate value IN 1..5
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        self.assertFalse(session.HasAnyError())
+        checker = SemanticChecker(session)
+        root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 0)
+
+    def test_validate_unknown_identifier_fail(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain D {
+    context C {
+        valueobject V {
+            x: number validate value > nope
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        checker = SemanticChecker(session)
+        root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 1)
+        self.assertTrue("nope" in session.diagnostics[0].toText())
+        self.assertTrue("not 'value' nor a sibling field" in session.diagnostics[0].toText())
+
+    def test_validate_unknown_function_fail(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain D {
+    context C {
+        valueobject V {
+            x: string validate size(value) > 0
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        checker = SemanticChecker(session)
+        root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 1)
+        self.assertTrue("Unknown function 'size'" in session.diagnostics[0].toText())
+
+    def test_validate_not_boolean_fail(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain D {
+    context C {
+        valueobject V {
+            x: number validate 5
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        checker = SemanticChecker(session)
+        root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 1)
+        self.assertTrue("must be a boolean condition" in session.diagnostics[0].toText())
+
 if __name__ == "__main__":
     unittest.main()

--- a/todo.txt
+++ b/todo.txt
@@ -17,8 +17,14 @@ TODO — d3i
     - Consider PolyPersist store/collection apis accepting EntityId<T> (typed) alongside
       `string id` (Find/Delete/Get), leaning on the implicit string conversion.
 
+[done] `validate` evaluation/codegen: parse tree -> validate_node AST (ElementBuilder);
+       lint (identifier resolution to value/sibling, known funcs len/matches + arity,
+       top-level boolean); .NET codegen -> PolyPersist.IValidable.Validate(errors) with a
+       guard per rule (own + inlined composite members; @optional -> null-guarded).
+       Known limits: len() assumes string (.Length); base-class (non-composite) validate
+       not chained; no client-side/TS validation yet.
+
 [deferred language codegen] see memory microniq-current-work.md:
-    - `validate` evaluation/codegen (expression text is captured only)
     - workflow Temporal runtime implementation
     - LSP: language_server.py calls main_module.lsp_initialize / lsp_did_open_text which
       are not defined in __main__.py -> broken; fix + smoke test.


### PR DESCRIPTION
Makes the `validate <expr>` sublanguage do something.

- **AST**: `ElementBuilder` builds a `validate_node` tree from the parse tree (member keeps raw text + `validate_ast`).
- **Lint**: identifiers must be `value` or a sibling field; functions known (`len`, `matches`) with correct arity (`matches` 2nd arg a string regex); the whole expression must be boolean.
- **Codegen (.NET)**: value objects/entities with validate rules implement `PolyPersist.IValidable`; generated `bool Validate(IList<IValidationError> errors)` emits a guard per rule. Inlined composite rules land in each consuming class; `@optional` members are null-guarded. Maps and/or/not, comparisons, `IN a..b`, `IN {set}`, `BETWEEN`, `len()`->`.Length`, `matches()`->`Regex.IsMatch`.

Known limits: `len()` assumes string; base-class (non-composite) validate not chained; no client-side/TS validation yet. 6 new tests, 161 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)