### PR TITLE
validate: type-aware lint + human-readable codegen

### DIFF
--- a/d3i/emitters/DotnetEmitter.py
+++ b/d3i/emitters/DotnetEmitter.py
@@ -417,57 +417,138 @@ class DotnetEmitter:
         return code
 
     def dataClassValidateText(self, name: str, validate_members: List[hinted_base_element], code: dotnet_code, indent: int = 1) -> str:
-        # Generates `bool Validate(IList<IValidationError> errors)` (PolyPersist.IValidable):
-        # one guard per member rule; a failing rule appends a ValidationError.
+        # Generates `bool Validate(IList<IValidationError> errors)` (PolyPersist.IValidable).
+        # Each rule becomes an `if (<violated>)` that records a readable error; the guard is
+        # the NEGATION of the rule folded into the operators (so `value > 0` reads `amount <= 0`,
+        # not `!(amount > 0)`) with bare field names and only the parentheses precedence needs.
         buffer = io.StringIO()
         buffer.write(f"\n")
         buffer.write(f"{utils.tab(indent)}#region Validation\n")
         buffer.write(f"{utils.tab(indent)}public bool Validate( IList<IValidationError> errors )\n")
         buffer.write(f"{utils.tab(indent)}{{\n")
-        buffer.write(f"{utils.tab(indent+1)}int __start = errors.Count;\n")
+        buffer.write(f"{utils.tab(indent+1)}int before = errors.Count;\n")
         for member in validate_members:
-            condition = self.validateExprText(member.validate_ast, member.name, code)
-            # an @optional (nullable) member is only validated when present
+            violated = self.__validateViolation(member.validate_ast, member, code)
             if (member.find_decorator("optional") != None):
-                guard = f"this.{member.name} != null && !({condition})"
-            else:
-                guard = f"!({condition})"
-            errorText = member.validate.replace("\\", "\\\\").replace("\"", "\\\"")
-            buffer.write(f"{utils.tab(indent+1)}if ({guard})\n")
-            buffer.write(f"{utils.tab(indent+2)}errors.Add( new ValidationError {{ TypeOfEntity = \"{name}\", MemberOfEntity = \"{member.name}\", ErrorText = \"validation failed: {errorText}\" }} );\n")
-        buffer.write(f"{utils.tab(indent+1)}return errors.Count == __start;\n")
+                violated = f"{member.name} != null && ({violated})"
+            message = self.__validateRuleText(member.validate_ast).replace("\\", "\\\\").replace("\"", "\\\"")
+            buffer.write(f"\n")
+            buffer.write(f"{utils.tab(indent+1)}if ({violated})\n")
+            buffer.write(f"{utils.tab(indent+2)}errors.Add( new ValidationError {{ TypeOfEntity = \"{name}\", MemberOfEntity = \"{member.name}\", ErrorText = \"{member.name} must satisfy: {message}\" }} );\n")
+        buffer.write(f"\n")
+        buffer.write(f"{utils.tab(indent+1)}return errors.Count == before;\n")
         buffer.write(f"{utils.tab(indent)}}}\n")
         buffer.write(f"{utils.tab(indent)}#endregion Validation\n")
         return buffer.getvalue()
 
-    def validateExprText(self, node: validate_node, member_name: str, code: dotnet_code) -> str:
-        # maps a validate AST node to a C# boolean/value expression
+    # C# for "the rule is VIOLATED" (negation folded into the operators)
+    def __validateViolation(self, node: validate_node, member: hinted_base_element, code: dotnet_code) -> str:
         if (isinstance(node, validate_binary)):
-            left = self.validateExprText(node.left, member_name, code)
-            right = self.validateExprText(node.right, member_name, code)
-            op = {"and": "&&", "or": "||"}.get(node.op, node.op)   # comparisons pass through
-            return f"({left} {op} {right})"
+            if (node.op == "and"):
+                return f"{self.__violationOperand(node.left, member, code)} || {self.__violationOperand(node.right, member, code)}"
+            if (node.op == "or"):
+                return f"{self.__violationOperand(node.left, member, code)} && {self.__violationOperand(node.right, member, code)}"
+            flipped = {"<": ">=", "<=": ">", ">": "<=", ">=": "<", "==": "!=", "!=": "=="}[node.op]
+            return f"{self.__validateValue(node.left, member, code)} {flipped} {self.__validateValue(node.right, member, code)}"
         if (isinstance(node, validate_not)):
-            return f"(!({self.validateExprText(node.operand, member_name, code)}))"
+            return self.__validateTruth(node.operand, member, code)
         if (isinstance(node, validate_in_range) or isinstance(node, validate_between)):
-            term = self.validateExprText(node.term, member_name, code)
-            low = self.validateExprText(node.low, member_name, code)
-            high = self.validateExprText(node.high, member_name, code)
-            return f"({term} >= {low} && {term} <= {high})"
+            term = self.__validateValue(node.term, member, code)
+            return f"{term} < {self.__validateValue(node.low, member, code)} || {term} > {self.__validateValue(node.high, member, code)}"
         if (isinstance(node, validate_in_set)):
-            term = self.validateExprText(node.term, member_name, code)
-            parts = [f"{term} == {self.validateExprText(item, member_name, code)}" for item in node.items]
-            return "(" + " || ".join(parts) + ")"
-        if (isinstance(node, validate_call)):
-            args = [self.validateExprText(arg, member_name, code) for arg in node.args]
-            if (node.func == "len"):
-                return f"({args[0]}).Length"
-            if (node.func == "matches"):
-                return f"System.Text.RegularExpressions.Regex.IsMatch({args[0]}, {args[1]})"
-            return f"{node.func}({', '.join(args)})"
+            term = self.__validateValue(node.term, member, code)
+            return " && ".join([f"{term} != {self.__validateValue(item, member, code)}" for item in node.items])
+        if (isinstance(node, validate_call)):   # matches -> a boolean, violated is the negation
+            return f"!{self.__validateTruth(node, member, code)}"
+        if (isinstance(node, validate_ref)):    # a boolean field
+            return f"!{self.__validateValue(node, member, code)}"
+        return f"!({self.__validateTruth(node, member, code)})"
+
+    def __violationOperand(self, node: validate_node, member: hinted_base_element, code: dotnet_code) -> str:
+        text = self.__validateViolation(node, member, code)
+        return f"({text})" if self.__validateCompound(node) else text
+
+    # C# for "the rule holds" (positive form)
+    def __validateTruth(self, node: validate_node, member: hinted_base_element, code: dotnet_code) -> str:
+        if (isinstance(node, validate_binary)):
+            if (node.op == "and" or node.op == "or"):
+                op = "&&" if (node.op == "and") else "||"
+                return f"{self.__truthOperand(node.left, member, code)} {op} {self.__truthOperand(node.right, member, code)}"
+            return f"{self.__validateValue(node.left, member, code)} {node.op} {self.__validateValue(node.right, member, code)}"
+        if (isinstance(node, validate_not)):
+            return f"!({self.__validateTruth(node.operand, member, code)})"
+        if (isinstance(node, validate_in_range) or isinstance(node, validate_between)):
+            term = self.__validateValue(node.term, member, code)
+            return f"{term} >= {self.__validateValue(node.low, member, code)} && {term} <= {self.__validateValue(node.high, member, code)}"
+        if (isinstance(node, validate_in_set)):
+            term = self.__validateValue(node.term, member, code)
+            return " || ".join([f"{term} == {self.__validateValue(item, member, code)}" for item in node.items])
+        return self.__validateValue(node, member, code)
+
+    def __truthOperand(self, node: validate_node, member: hinted_base_element, code: dotnet_code) -> str:
+        text = self.__validateTruth(node, member, code)
+        return f"({text})" if self.__validateCompound(node) else text
+
+    # does this node produce a boolean built from && / || (so it needs parens as an operand)?
+    def __validateCompound(self, node: validate_node) -> bool:
+        if (isinstance(node, validate_binary)):
+            return node.op == "and" or node.op == "or"
+        if (isinstance(node, validate_in_range) or isinstance(node, validate_between)):
+            return True
+        if (isinstance(node, validate_in_set)):
+            return len(node.items) > 1
+        if (isinstance(node, validate_not)):
+            return False
+        return False
+
+    # C# for a plain value operand (bare field name, literal, or a function result)
+    def __validateValue(self, node: validate_node, member: hinted_base_element, code: dotnet_code) -> str:
         if (isinstance(node, validate_ref)):
-            target = member_name if (node.name == "value") else node.name
-            return f"this.{target}"
+            return member.name if (node.name == "value") else node.name
+        if (isinstance(node, validate_literal)):
+            return node.value
+        if (isinstance(node, validate_call)):
+            if (node.func == "len"):
+                target = self.__validateValue(node.args[0], member, code)
+                accessor = "Count" if self.__validateIsCollection(node.args[0], member) else "Length"
+                return f"{target}.{accessor}"
+            if (node.func == "matches"):
+                code.usings.add("System.Text.RegularExpressions")
+                return f"Regex.IsMatch({self.__validateValue(node.args[0], member, code)}, {self.__validateValue(node.args[1], member, code)})"
+        return self.__validateTruth(node, member, code)
+
+    def __validateIsCollection(self, node: validate_node, member: hinted_base_element) -> bool:
+        # a len() argument is `value` (this member) or a sibling; list/map -> .Count, else .Length
+        if (isinstance(node, validate_ref) == False):
+            return False
+        target = member
+        if (node.name != "value"):
+            target = None
+            for candidate in member.parent.members:
+                if (candidate.name == node.name):
+                    target = candidate
+                    break
+        if (target == None or target.type == None):
+            return False
+        return target.type.kind == type.Kind.List or target.type.kind == type.Kind.Map
+
+    # a readable rendering of the rule for the error message (spaces, uppercase AND/OR)
+    def __validateRuleText(self, node: validate_node) -> str:
+        if (isinstance(node, validate_binary)):
+            op = node.op.upper() if (node.op == "and" or node.op == "or") else node.op
+            return f"{self.__validateRuleText(node.left)} {op} {self.__validateRuleText(node.right)}"
+        if (isinstance(node, validate_not)):
+            return f"NOT ({self.__validateRuleText(node.operand)})"
+        if (isinstance(node, validate_in_range)):
+            return f"{self.__validateRuleText(node.term)} IN {self.__validateRuleText(node.low)}..{self.__validateRuleText(node.high)}"
+        if (isinstance(node, validate_between)):
+            return f"{self.__validateRuleText(node.term)} BETWEEN {self.__validateRuleText(node.low)} AND {self.__validateRuleText(node.high)}"
+        if (isinstance(node, validate_in_set)):
+            return f"{self.__validateRuleText(node.term)} IN {{{', '.join([self.__validateRuleText(i) for i in node.items])}}}"
+        if (isinstance(node, validate_call)):
+            return f"{node.func}({', '.join([self.__validateRuleText(a) for a in node.args])})"
+        if (isinstance(node, validate_ref)):
+            return node.name
         if (isinstance(node, validate_literal)):
             return node.value
         return ""

--- a/d3i/linters/SemanticChecker.py
+++ b/d3i/linters/SemanticChecker.py
@@ -412,46 +412,121 @@ class SemanticChecker(ElementVisitor):
     __VALIDATE_FUNCS = {"len": 1, "matches": 2}
 
     def __check_validate(self, member: base_element):
-        node = member.validate_ast
-        if (node == None):
+        # Type-checks the validate expression against the field types: a rule may only use
+        # operations that make sense for the type (e.g. no `> 0` on a string), and the whole
+        # expression must be boolean. Categories: number, string, bool, temporal (date/time),
+        # collection (list/map), enum, id (ref), unknown.
+        if (member.validate_ast == None):
             return
-        # the whole expression must be a boolean condition, not a bare value/literal.
-        if (isinstance(node, (validate_ref, validate_literal))):
-            self.__error(member, f"The 'validate' expression on '{member.name}' must be a boolean condition.")
-        sibling_names = [m.name for m in member.parent.members]
-        self.__walk_validate(node, member, sibling_names)
+        category = self.__validate_type(member.validate_ast, member)
+        if (category != "bool" and category != "error"):
+            self.__error(member, f"The 'validate' expression on '{member.name}' must be a boolean condition, but it is a '{category}'.")
 
-    def __walk_validate(self, node, member: base_element, sibling_names: list):
-        if (isinstance(node, validate_binary)):
-            self.__walk_validate(node.left, member, sibling_names)
-            self.__walk_validate(node.right, member, sibling_names)
-        elif (isinstance(node, validate_not)):
-            self.__walk_validate(node.operand, member, sibling_names)
-        elif (isinstance(node, validate_in_range)):
-            self.__walk_validate(node.term, member, sibling_names)
-            self.__walk_validate(node.low, member, sibling_names)
-            self.__walk_validate(node.high, member, sibling_names)
-        elif (isinstance(node, validate_in_set)):
-            self.__walk_validate(node.term, member, sibling_names)
-            for item in node.items:
-                self.__walk_validate(item, member, sibling_names)
-        elif (isinstance(node, validate_between)):
-            self.__walk_validate(node.term, member, sibling_names)
-            self.__walk_validate(node.low, member, sibling_names)
-            self.__walk_validate(node.high, member, sibling_names)
-        elif (isinstance(node, validate_call)):
-            if (node.func not in self.__VALIDATE_FUNCS):
-                self.__error(member, f"Unknown function '{node.func}' in the 'validate' on '{member.name}' (known: len, matches).")
-            elif (len(node.args) != self.__VALIDATE_FUNCS[node.func]):
-                self.__error(member, f"Function '{node.func}' in the 'validate' on '{member.name}' expects {self.__VALIDATE_FUNCS[node.func]} argument(s), got {len(node.args)}.")
-            elif (node.func == "matches" and (isinstance(node.args[1], validate_literal) == False or node.args[1].kind != "string")):
-                self.__error(member, f"The second argument of 'matches' in the 'validate' on '{member.name}' must be a string regex literal.")
-            for arg in node.args:
-                self.__walk_validate(arg, member, sibling_names)
-        elif (isinstance(node, validate_ref)):
-            if (node.name != "value" and node.name not in sibling_names):
+    def __validate_type(self, node, member: base_element) -> str:
+        if (isinstance(node, validate_literal)):
+            return "number" if (node.kind == "int" or node.kind == "number") else "string"
+
+        if (isinstance(node, validate_ref)):
+            if (node.name == "value"):
+                return self.__type_category(member.type)
+            sibling = None
+            for candidate in member.parent.members:
+                if (candidate.name == node.name):
+                    sibling = candidate
+                    break
+            if (sibling == None):
                 self.__error(member, f"'{node.name}' in the 'validate' on '{member.name}' is not 'value' nor a sibling field.")
-        # validate_literal: nothing to check
+                return "error"
+            return self.__type_category(sibling.type)
+
+        if (isinstance(node, validate_call)):
+            return self.__validate_call_type(node, member)
+
+        if (isinstance(node, validate_not)):
+            inner = self.__validate_type(node.operand, member)
+            if (inner != "bool" and inner != "error"):
+                self.__error(member, f"'not' in the 'validate' on '{member.name}' needs a boolean operand, not a '{inner}'.")
+            return "bool"
+
+        if (isinstance(node, validate_binary)):
+            left = self.__validate_type(node.left, member)
+            right = self.__validate_type(node.right, member)
+            if (node.op == "and" or node.op == "or"):
+                for side in (left, right):
+                    if (side != "bool" and side != "error"):
+                        self.__error(member, f"'{node.op}' in the 'validate' on '{member.name}' needs boolean operands, not a '{side}'.")
+                return "bool"
+            if (node.op in ("<", "<=", ">", ">=")):
+                for side in (left, right):
+                    if (side != "error" and side != "number" and side != "temporal"):
+                        self.__error(member, f"'{node.op}' in the 'validate' on '{member.name}' needs ordered values (number or date), not a '{side}'.")
+                return "bool"
+            # == or !=
+            if (left != "error" and right != "error" and left != right):
+                self.__error(member, f"'{node.op}' in the 'validate' on '{member.name}' compares incompatible types '{left}' and '{right}'.")
+            return "bool"
+
+        if (isinstance(node, validate_in_range) or isinstance(node, validate_between)):
+            term = self.__validate_type(node.term, member)
+            self.__validate_type(node.low, member)
+            self.__validate_type(node.high, member)
+            if (term != "error" and term != "number" and term != "temporal"):
+                self.__error(member, f"the range check in the 'validate' on '{member.name}' needs an ordered value (number or date), not a '{term}'.")
+            return "bool"
+
+        if (isinstance(node, validate_in_set)):
+            term = self.__validate_type(node.term, member)
+            for item in node.items:
+                item_category = self.__validate_type(item, member)
+                if (term != "error" and item_category != "error" and term != item_category):
+                    self.__error(member, f"the set check in the 'validate' on '{member.name}' mixes a '{term}' with a '{item_category}'.")
+            return "bool"
+
+        return "error"
+
+    def __validate_call_type(self, node, member: base_element) -> str:
+        if (node.func not in self.__VALIDATE_FUNCS):
+            self.__error(member, f"Unknown function '{node.func}' in the 'validate' on '{member.name}' (known: len, matches).")
+            return "error"
+        if (len(node.args) != self.__VALIDATE_FUNCS[node.func]):
+            self.__error(member, f"Function '{node.func}' in the 'validate' on '{member.name}' expects {self.__VALIDATE_FUNCS[node.func]} argument(s), got {len(node.args)}.")
+            return "error"
+        arg_categories = [self.__validate_type(arg, member) for arg in node.args]
+        if (node.func == "len"):
+            if (arg_categories[0] != "error" and arg_categories[0] != "string" and arg_categories[0] != "collection"):
+                self.__error(member, f"'len' in the 'validate' on '{member.name}' needs a string or a list/map, not a '{arg_categories[0]}'.")
+            return "number"
+        # matches
+        if (arg_categories[0] != "error" and arg_categories[0] != "string"):
+            self.__error(member, f"'matches' in the 'validate' on '{member.name}' needs a string, not a '{arg_categories[0]}'.")
+        if (isinstance(node.args[1], validate_literal) == False or node.args[1].kind != "string"):
+            self.__error(member, f"the second argument of 'matches' in the 'validate' on '{member.name}' must be a string regex literal.")
+        return "bool"
+
+    def __type_category(self, the_type) -> str:
+        if (the_type == None):
+            return "unknown"
+        if (the_type.kind == type.Kind.List or the_type.kind == type.Kind.Map):
+            return "collection"
+        if (the_type.kind == type.Kind.Ref):
+            return "id"
+        if (the_type.kind == type.Kind.Reference):
+            element = Engine.get_referenced_element(the_type.parent, the_type.reference_name)
+            if (isinstance(element, enum)):
+                return "enum"
+            return "unknown"
+        if (the_type.kind == type.Kind.Primitive):
+            kind = the_type.primtiveKind
+            if (kind == primitive_type.PrimtiveKind.Integer or kind == primitive_type.PrimtiveKind.Number):
+                return "number"
+            if (kind == primitive_type.PrimtiveKind.Date or kind == primitive_type.PrimtiveKind.Time or kind == primitive_type.PrimtiveKind.DateTime):
+                return "temporal"
+            if (kind == primitive_type.PrimtiveKind.String or kind == primitive_type.PrimtiveKind.I18NString):
+                return "string"
+            if (kind == primitive_type.PrimtiveKind.Boolean):
+                return "bool"
+            return "unknown"
+        return "unknown"
 
     def __is_on_interface_surface(self, element: base_element) -> bool:
         # True when the element sits inside an interface (its dto members or its

--- a/tests/test_emitter_dotnet.py
+++ b/tests/test_emitter_dotnet.py
@@ -787,13 +787,32 @@ domain Shop {
         self.assertIn("using PolyPersist.Net.Common;", content)
         self.assertIn(", IValidable", content)
         self.assertIn("public bool Validate( IList<IValidationError> errors )", content)
-        # own rule
-        self.assertIn("(this.amount > 0) && (this.amount <= 1000)", content)
-        # inlined composite rule (zipCode) lands in Order.Validate
+        # own rule: readable, negation folded into the operators, bare field names
+        self.assertIn("if (amount <= 0 || amount > 1000)", content)
+        # inlined composite rule (zipCode) lands in Order.Validate; string len -> .Length
         self.assertIn('MemberOfEntity = "zipCode"', content)
-        self.assertIn("(this.zipCode).Length == 4", content)
+        self.assertIn("if (zipCode.Length != 4)", content)
         # @optional member is guarded by a null-check
-        self.assertIn("this.note != null && !(", content)
+        self.assertIn("note != null && (", content)
+
+    def test_emitter_validate_collection_len_count(self):
+        # len() on a list/map maps to .Count (not .Length)
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain Shop {
+    context C {
+        valueobject Cart {
+            items: list[string] validate len(value) <= 3
+        }
+    }
+}
+"""))
+        engine.Build(session)
+        self.assertFalse(session.HasAnyError())
+
+        result = DotnetEmitter().Emit(session)
+        content = next(f for f in result if f.fileName == "Cart.cs").content
+        self.assertIn("if (items.Count > 3)", content)
 
 
 if __name__ == "__main__":

--- a/tests/test_linter_semantic_checker.py
+++ b/tests/test_linter_semantic_checker.py
@@ -1309,6 +1309,44 @@ domain D {
         self.assertEqual(len(session.diagnostics), 1)
         self.assertTrue("Unknown function 'size'" in session.diagnostics[0].toText())
 
+    def test_validate_type_mismatch_fail(self):
+        # you cannot order-compare a string ( `> 0` needs a number/date )
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain D {
+    context C {
+        valueobject V {
+            name: string validate value > 0
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        checker = SemanticChecker(session)
+        root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 1)
+        self.assertTrue("needs ordered values" in session.diagnostics[0].toText())
+
+    def test_validate_len_on_number_fail(self):
+        engine = Engine()
+        session = Session(Source.CreateFromText("""
+domain D {
+    context C {
+        valueobject V {
+            n: integer validate len(value) > 0
+        }
+    }
+}
+"""))
+        root = engine.Build(session)
+        checker = SemanticChecker(session)
+        root.visit(checker, None)
+        session.PrintDiagnostics()
+        self.assertEqual(len(session.diagnostics), 1)
+        self.assertTrue("'len'" in session.diagnostics[0].toText())
+        self.assertTrue("string or a list/map" in session.diagnostics[0].toText())
+
     def test_validate_not_boolean_fail(self):
         engine = Engine()
         session = Session(Source.CreateFromText("""

--- a/todo.txt
+++ b/todo.txt
@@ -18,11 +18,14 @@ TODO — d3i
       `string id` (Find/Delete/Get), leaning on the implicit string conversion.
 
 [done] `validate` evaluation/codegen: parse tree -> validate_node AST (ElementBuilder);
-       lint (identifier resolution to value/sibling, known funcs len/matches + arity,
-       top-level boolean); .NET codegen -> PolyPersist.IValidable.Validate(errors) with a
-       guard per rule (own + inlined composite members; @optional -> null-guarded).
-       Known limits: len() assumes string (.Length); base-class (non-composite) validate
-       not chained; no client-side/TS validation yet.
+       TYPE-AWARE lint (identifiers resolve to value/sibling; operations must fit the field
+       type: ordering only on number/date, len only on string/list/map, matches only on
+       string, == on same category; top-level boolean); .NET codegen -> PolyPersist.IValidable
+       with readable guards (negation folded into operators, bare field names, minimal parens,
+       len -> .Length for string / .Count for list/map; @optional -> null-guarded).
+       Remaining: base-class (non-composite) validate not chained (call base.Validate);
+       no negative literals in the validate grammar (`-10` doesn't tokenize);
+       no client-side/TS validation yet.
 
 [deferred language codegen] see memory microniq-current-work.md:
     - workflow Temporal runtime implementation


### PR DESCRIPTION
Follow-up to the `validate` feature, addressing two rough edges.

**Type-aware lint** — a rule may only use operations that fit the field's type: a string can't be `> 0`, `len` needs a string or list/map, `matches` needs a string, ordering (`< <= > >=`, `IN a..b`, `BETWEEN`) needs number/date, `==`/`!=` need the same category. Otherwise the linter reports it (no more non-compiling codegen slipping through).

**Human-readable codegen** — the generated guard is the NEGATION of the rule folded into the operators, with bare field names and minimal parens:

```
value > 0 AND value <= 1000   ->   if (amount <= 0 || amount > 1000)
len(value) IN 5..10           ->   if (coupon.Length < 5 || coupon.Length > 10)
```

`len` now maps to `.Length` for strings and `.Count` for list/map. Error messages render the rule readably (`"amount must satisfy: value > 0 AND value <= 1000"`).

3 new tests, 164 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)