### PR TITLE
Remove Rust emitter targets

### DIFF
--- a/d3i/__main__.py
+++ b/d3i/__main__.py
@@ -22,8 +22,6 @@ EMITTER_TARGETS = {
     "typescript:backend": (None,                             "typescript", "backend",  "invalid",   "TypeScript is client-only; there is no server runtime (Node is not supported)"),
     "java:backend":       (None,                             "java",       "backend",  "planned",   ""),
     "java:client":        (None,                             "java",       "client",   "planned",   ""),
-    "rust:backend":       (None,                             "rust",       "backend",  "planned",   ""),
-    "rust:client":        (None,                             "rust",       "client",   "planned",   ""),
     # Side-agnostic contract emitters (needed by every implementation).
     "proto":              ("d3i.emitters.ProtoEmitter",      "proto",      "contract", "supported", ""),
     "json":               ("d3i.emitters.JsonEmitter",       "json",       "contract", "supported", ""),

--- a/tests/test_cli_emitter_targets.py
+++ b/tests/test_cli_emitter_targets.py
@@ -53,11 +53,6 @@ class TestCliEmitterTargets(unittest.TestCase):
             resolve_emitter("java:backend")
         self.assertIn("planned but not implemented", str(cm.exception))
 
-    def test_planned_rust_client(self):
-        with self.assertRaises(SystemExit) as cm:
-            resolve_emitter("rust:client")
-        self.assertIn("planned but not implemented", str(cm.exception))
-
     # --- bare language name needs a side --------------------------------------
 
     def test_bare_language_needs_side(self):


### PR DESCRIPTION
Drops the planned `rust:backend`/`rust:client` targets from EMITTER_TARGETS and removes the matching CLI test. .NET/TypeScript/Java/Proto/JSON remain. Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)